### PR TITLE
Fix/airflow test names

### DIFF
--- a/Tests/Airflow_Agent_USGS_Earthquake_To_PostgreSQL/test_airflow_agent_usgs_earthquake_to_postgresql.py
+++ b/Tests/Airflow_Agent_USGS_Earthquake_To_PostgreSQL/test_airflow_agent_usgs_earthquake_to_postgresql.py
@@ -47,7 +47,7 @@ def get_fixtures() -> List[DEBenchFixture]:
 
     # Initialize GitHub fixture for PR and branch management
     custom_github_config = {
-        "resource_id": f"test_usgs_earthquake_test_{test_timestamp}_{test_uuid}",
+        "resource_id": f"test_airflow_usgs_earthquake_test_{test_timestamp}_{test_uuid}",
     }
 
     airflow_fixture = AirflowFixture(custom_config=custom_airflow_config)

--- a/Tests/Airflow_Agent_YFinance_To_PostgreSQL/test_airflow_agent_yfinance_to_postgresql.py
+++ b/Tests/Airflow_Agent_YFinance_To_PostgreSQL/test_airflow_agent_yfinance_to_postgresql.py
@@ -47,7 +47,7 @@ def get_fixtures() -> List[DEBenchFixture]:
 
     # Initialize GitHub fixture for PR and branch management
     custom_github_config = {
-        "resource_id": f"test_yfinance_tesla_test_{test_timestamp}_{test_uuid}",
+        "resource_id": f"test_airflow_yfinance_tesla_test_{test_timestamp}_{test_uuid}",
     }
 
     airflow_fixture = AirflowFixture(custom_config=custom_airflow_config)

--- a/Tests/Airflow_Agent_and_PostgreSQL_Agent_Database_Deduplication/test_airflow_agent_and_postgresql_agent_database_deduplication.py
+++ b/Tests/Airflow_Agent_and_PostgreSQL_Agent_Database_Deduplication/test_airflow_agent_and_postgresql_agent_database_deduplication.py
@@ -47,7 +47,7 @@ def get_fixtures() -> List[DEBenchFixture]:
 
     # Initialize GitHub fixture for PR and branch management
     custom_github_config = {
-        "resource_id": f"test_db_deduplication_test_{test_timestamp}_{test_uuid}",
+        "resource_id": f"test_airlfow_db_deduplication_test_{test_timestamp}_{test_uuid}",
     }
 
     airflow_fixture = AirflowFixture(custom_config=custom_airflow_config)

--- a/Tests/TESTS.md
+++ b/Tests/TESTS.md
@@ -425,6 +425,7 @@ Invalid tests are automatically excluded from execution.
 2. **Missing connection parameters**: Store `_connection_params` during setup
 3. **Configuration key mismatches**: Ensure fixture config keys match `Configure_Model.py` expectations
 4. **Resource cleanup issues**: Implement proper `teardown_resource()` methods
+5. **Airflow GitHub branch names**: Airflow test names for the github_resource fixture should start with `test_airflow_`. This is naming convention is used to trigger redeploying the Astronomer cloud deployment.
 
 ### Debugging
 


### PR DESCRIPTION
This PR fixes the test names for the github branch names for the airflow tests. It is required that they start with `test_airflow` so that the test workflow kicks off and redeploys the Astronomer cloud deployments. I also updated the new TESTS.md documentation to reflect this.