### PR TITLE
Fix/airflow fixture with braintrust

### DIFF
--- a/Tests/TESTS.md
+++ b/Tests/TESTS.md
@@ -409,6 +409,26 @@ python run_braintrust_eval.py --filter "Airflow_Agent.*" Ardent
 python run_braintrust_eval.py Ardent
 ```
 
+### Designating Agents
+- Currently we support running tests with the following agents:
+    - Ardent
+    - Claude_Code
+    - OpenAI_Codex
+- Specify which agent to use after all parameters and values
+- Example usage of stating which agent to use for testing
+```bash
+# To run all three agents
+python run_braintrust_eval.py --filter "Airflow_Agent.*" Ardent Claude_Code OpenAI_Codex
+
+# To run two agents
+python run_braintrust_eval.py --filter "Airflow_Agent.*" Ardent Claude_Code
+
+# If no agent is specified, it will default to Ardent
+python run_braintrust_eval.py --filter "Airflow_Agent.*"
+# The above is the same as the following command
+python run_braintrust_eval.py --filter "Airflow_Agent.*" Ardent
+```
+
 ## Test Discovery
 
 Tests are automatically discovered by scanning the `Tests/` directory for:

--- a/model/Configure_Model.py
+++ b/model/Configure_Model.py
@@ -160,12 +160,17 @@ def set_up_model_configs(Configs, custom_info=None):
                             "X-Braintrust-Exported-Parent-Span": current_span().export(),
                         },
                     )
+                else:
+                    # Handle unknown service types
+                    print(f"⚠️ Unknown service type: {service}")
+                    service_result = None
 
                 # Add the result to our results dictionary
-                if not results:
-                    results = {service: service_result}
-                else:
-                    results[service] = service_result
+                if service_result is not None:
+                    if not results:
+                        results = {service: service_result}
+                    else:
+                        results[service] = service_result
     elif mode == "Claude_Code":
         # set up the kubernetes job
 

--- a/run_braintrust_eval.py
+++ b/run_braintrust_eval.py
@@ -429,6 +429,8 @@ def discover_available_tests(
     if filter_patterns:
         filtered_tests = []
         for test_name in available_tests:
+            if isinstance(filter_patterns, str):
+                filter_patterns = [filter_patterns]
             for pattern in filter_patterns:
                 try:
                     if re.search(pattern, test_name, re.IGNORECASE):


### PR DESCRIPTION
This PR fixes the following errors with the Airflow_Fixture with braintrust:
- It doesn't allocate an instance
- It doesn't filter tests correctly, eg providing --filter Airflow_Agent_Hello_Universe* returns all tests after filtering
- AttributeError: 'AirflowFixture' object has no attribute '_resource_data'
- Referring to a non-existent variable in `verify_airflow_dag_exists` method in `Fixtures/Airflow/Airflow.py`

I also updated the documentation on how to specify which agent to use in a test.